### PR TITLE
Stricter companies house number validation

### DIFF
--- a/companies_house_prefixes.txt
+++ b/companies_house_prefixes.txt
@@ -1,0 +1,60 @@
+Companies registered in England and Wales 
+-------------------------------------------------------------------------------- 
+AC - Assurance companies 
+
+BR - UK Establishment of an overseas company 
+
+FC - Overseas companies 
+
+GE - EEIG - European Economic Interest Grouping 
+
+IP - Industrial and Provident Societies 
+
+LP - Limited Partnership 
+
+OC - Limited Liability Partnership 
+
+RC - Incorporated by Royal Charter or Letters Patent. 
+
+SE - Societas Europea - Refer queries to Overseas team 
+
+ZC - Unregistered company (Company registered under an Act other than the Companies Act). 
+
+
+Companies Registered in Scotland 
+-------------------------------------------------------------------------------- 
+SC - Companies Registered under Part 1 of the Companies Act 1985 
+
+SA - Assurance Companies 
+
+SF - Overseas Companies which appear to have a place of business in Scotland 
+
+SL - Limited Partnerships 
+
+SZ - Companies Incorporated under other than Companies Acts 
+
+SP - Industrial and Provident Societies 
+
+SO - Other Companies and LLP's 
+
+SR - Incorporated by Royal Charter or Letters Patent 
+
+
+
+Companies Registered in Northern Ireland 
+--------------------------------------------------------------------------- 
+NI - Companies Registered under Part 1 of the Companies Act (Northern Ireland) 1960 
+
+NA - Assurance Companies 
+
+NF - Overseas Companies which appear to have a place of business in Northern Ireland 
+
+NL - Limited Partnerships 
+
+NZ - Companies Incorporated under other than Companies Acts 
+
+NP - Industrial and Provident Societies 
+
+NO - Other Companies 
+
+NR - Incorporated by Royal Charter or Letters Patent 

--- a/lib/companies_house/request.rb
+++ b/lib/companies_house/request.rb
@@ -4,6 +4,11 @@ module CompaniesHouse
 
     BASE_URI = 'http://data.companieshouse.gov.uk/doc/company/'
 
+    # White list of allowed prefixes for companies house numbers.
+    # 1st line is English and Welsh prefixes
+    # 2nd line is Scottish prefixes
+    # 3rd line is Northen Irish prefixes
+    # \d\d is the default prefix in regex notation.
     ALLOWED_PREFIXES = %w(AC BR FC GE IP LP OC RC SE ZC
                           SC SA SF SL SZ SP SO SR
                           NI NA NF NL NZ NP NO NR

--- a/lib/companies_house/request.rb
+++ b/lib/companies_house/request.rb
@@ -4,6 +4,11 @@ module CompaniesHouse
 
     BASE_URI = 'http://data.companieshouse.gov.uk/doc/company/'
 
+    ALLOWED_PREFIXES = %w(AC BR FC GE IP LP OC RC SE ZC
+                          SC SA SF SL SZ SP SO SR
+                          NI NA NF NL NZ NP NO NR
+                          \d\d)
+
     # Don't call this directly. Instead, use CompaniesHouse.lookup "01234567"
     def initialize(registration_number)
       @registration_number = validate(registration_number)
@@ -29,8 +34,11 @@ module CompaniesHouse
 
       number = "0" + number if number.length == 7 # 0-pad for luck
 
+      companies_house_regex = Regexp.
+        new("\\A(#{ALLOWED_PREFIXES * '|'})\\d{6}\\z")
+
       msg = "#{number} is not a valid UK company registration number"
-      raise InvalidRegistration.new(msg) unless number =~ /\A[A-Z0-9]{8}\z/
+      raise InvalidRegistration.new(msg) unless number =~ companies_house_regex
 
       number
     end

--- a/lib/companies_house/version.rb
+++ b/lib/companies_house/version.rb
@@ -1,3 +1,3 @@
 module CompaniesHouse
-  VERSION = '0.2.2'.freeze
+  VERSION = '0.2.3'.freeze
 end

--- a/spec/companies_house/request_spec.rb
+++ b/spec/companies_house/request_spec.rb
@@ -37,6 +37,15 @@ describe CompaniesHouse::Request do
       end
     end
 
+    CompaniesHouse::Request::ALLOWED_PREFIXES.each do |prefix|
+      it "allows a company registration number starting with #{prefix}" do
+        prefix = (prefix == '\d\d') ? '07' : prefix
+        company = subject.new "#{prefix}112233"
+        company.instance_variable_get(:@registration_number).
+          should == "#{prefix}112233"
+      end
+    end
+
     it "0-pads 7 digit registration numbers" do
       company = subject.new "7495895"
       company.instance_variable_get(:@registration_number).


### PR DESCRIPTION
Enforces the prefix of a companies house number from a white list of
prefixes obtained from CompaniesHouse.
