### PR TITLE
Handle html error responses properly

### DIFF
--- a/lib/companies_house/response.rb
+++ b/lib/companies_house/response.rb
@@ -44,6 +44,9 @@ module CompaniesHouse
       body = response.body.encode("UTF-8", "ISO-8859-1")
       data = JSON.parse(body)
       @attributes = data["primaryTopic"]
+    rescue JSON::ParserError=> e
+      error_msg = "Companies house is having some errors: #{response.body}"
+      raise ServerError.new(error_msg)
     end
   end
 end

--- a/spec/companies_house/response_spec.rb
+++ b/spec/companies_house/response_spec.rb
@@ -58,4 +58,16 @@ describe CompaniesHouse::Response do
       }.to raise_exception CompaniesHouse::ServerError
     end
   end
+
+  context "when the server returns html" do
+    it "raises a companies house server error" do
+      http_response = stub('Response')
+      http_response.stubs(:body).returns("<html><head></head></html>")
+      http_response.stubs(:status).returns(200)
+
+      expect {
+        subject.new(http_response)
+      }.to raise_error(CompaniesHouse::ServerError)
+    end
+  end
 end


### PR DESCRIPTION
Companies house sometimes responds with a 200 status code containing an html response saying that they are having technical problems.

This PR detects this scenario and raises a `ServerError`
