### PR TITLE
Human readable response methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source "https://rubygems.org"
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -54,12 +54,24 @@ The following data is currently available on the `company` object returned by
 `CompaniesHouse.lookup`
 
 
-Call it like this:
+You can access the data in one of two ways:
+
+1) Directly from the hash:
 
 ```ruby
 company["RegAddress"]["AddressLine1"]
 => "22-25 FINSBURY SQUARE"
 ```
+
+2) As a human-readable method:
+
+```ruby
+company.reg_address.address_line1
+=> "22-25 FINSBURY SQUARE"
+```
+
+Note that this approach uses ActiveSupport's `camelize` method, so for more complicated keys, you may have to check the precise translation between the camelcase hash key and the human readable method.
+
 
 All data:
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ company.reg_address.address_line1
 => "22-25 FINSBURY SQUARE"
 ```
 
-Note that this approach uses ActiveSupport's `camelize` method, so for more complicated keys, you may have to check the precise translation between the camelcase hash key and the human readable method.
+Note that for more complicated keys, you may have to check the precise translation between the camelcase hash key and the human readable method.
 
 
 All data:

--- a/README.md
+++ b/README.md
@@ -107,6 +107,3 @@ All data:
   }
 }
 ```
-
-TODO: Use some funky metaprogramming to make these available as human-readable
-method calls, eg `company.name` or `company.registered_address.line_1`.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ company.reg_address.address_line1
 => "22-25 FINSBURY SQUARE"
 ```
 
-Note that for more complicated keys, you may have to check the precise translation between the camelcase hash key and the human readable method.
+Note that for more complicated keys, you may have to check the precise 
+translation between the camelcase hash key and the human readable method.
 
 
 All data:

--- a/lib/companies_house/response.rb
+++ b/lib/companies_house/response.rb
@@ -54,21 +54,21 @@ module CompaniesHouse
     end
 
     def define_accessor_methods
-    	@struct = build_open_struct(@attributes)
-			@struct.instance_variable_get("@table").keys.map(&:to_s).each do |key|
-  			instance_eval <<-"end_eval"
-	  			def #{key}
-	  				@struct.#{key}
-	  			end
-	  		end_eval
-	  	end
+      @struct = build_open_struct(@attributes)
+      @struct.instance_variable_get("@table").keys.map(&:to_s).each do |key|
+        instance_eval <<-"end_eval"
+          def #{key}
+            @struct.#{key}
+          end
+        end_eval
+      end
     end
 
     def build_open_struct(hash)
-    	hash.each_with_object(OpenStruct.new) do |(key, value), struct|
-  			value = build_open_struct(value) if value.is_a?(Hash)
-  			struct.send("#{key.underscore}=", value)
-    	end
+      hash.each_with_object(OpenStruct.new) do |(key, value), struct|
+        value = build_open_struct(value) if value.is_a?(Hash)
+        struct.send("#{key.underscore}=", value)
+      end
     end
 
   end

--- a/lib/companies_house/response.rb
+++ b/lib/companies_house/response.rb
@@ -47,13 +47,13 @@ module CompaniesHouse
       body = response.body.encode("UTF-8", "ISO-8859-1")
       data = JSON.parse(body)
       @attributes = data["primaryTopic"]
-      define_methods
+      define_accessor_methods
     rescue JSON::ParserError=> e
       error_msg = "Companies house is having problems: #{response.body}"
       raise ServerError.new(error_msg)
     end
 
-    def define_methods
+    def define_accessor_methods
     	@struct = build_open_struct(@attributes)
 			@struct.instance_variable_get("@table").keys.map(&:to_s).each do |key|
   			instance_eval <<-"end_eval"

--- a/open_companies_house.gemspec
+++ b/open_companies_house.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "faraday", "~> 0.8.4"
   gem.add_dependency "json"
+  gem.add_dependency "activesupport"
 
   gem.name = 'open-companies-house'
   gem.summary = "A wrapper around Companies House Open API"

--- a/spec/companies_house/response_spec.rb
+++ b/spec/companies_house/response_spec.rb
@@ -25,6 +25,14 @@ describe CompaniesHouse::Response do
     it "makes SIC code available as a convenience method" do
       @response.sic_code.should == "62090"
     end
+
+    it "makes attributes accessible as methods on the object body" do
+    	@response.company_name.should == "GOCARDLESS LTD"
+    end
+
+    it "makes nested attributes accessible as chained methods on the object body" do
+    	@response.reg_address.address_line1.should == "22-25 FINSBURY SQUARE"
+    end
   end
 
   context "with a company that doesn't exist" do

--- a/spec/companies_house/response_spec.rb
+++ b/spec/companies_house/response_spec.rb
@@ -27,11 +27,11 @@ describe CompaniesHouse::Response do
     end
 
     it "makes attributes accessible as methods on the object body" do
-    	@response.company_name.should == "GOCARDLESS LTD"
+      @response.company_name.should == "GOCARDLESS LTD"
     end
 
     it "makes nested attributes accessible as chained methods on the object body" do
-    	@response.reg_address.address_line1.should == "22-25 FINSBURY SQUARE"
+      @response.reg_address.address_line1.should == "22-25 FINSBURY SQUARE"
     end
   end
 


### PR DESCRIPTION
This patch defines a method on the `Response` object for every top-level key in the `@attributes` hash. If the value of the hash was a simple object, it will be returned when the method is called. If the value of the hash was _another_ hash, the method will return an `OpenStruct`, allowing the chaining of method calls.

For example, where previously you would have to call `company["RegAddress"]["AddressLine1"]`, you may now call `company.reg_address.address_line1`.

The existing `[]` method call is untouched and still available for use.
