### PR TITLE
Relax the faraday dependency

### DIFF
--- a/open_companies_house.gemspec
+++ b/open_companies_house.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'mocha', '~> 0.10.5'
   gem.add_development_dependency 'webmock', '~> 1.8.8'
 
-  gem.add_dependency "faraday", "~> 0.8.4"
+  gem.add_dependency "faraday"
   gem.add_dependency "json"
 
   gem.name = 'open-companies-house'


### PR DESCRIPTION
I'm not sure if there was a particular reason for requiring faraday ~> 0.8.4 but it was causing a dependency conflict in my project. With the version dependency removed, my project is now running faraday 0.9.2 and open-companies-house seems to be working fine.
